### PR TITLE
fix lz4 package name

### DIFF
--- a/slurm_build_ubuntu1804/Dockerfile
+++ b/slurm_build_ubuntu1804/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update && apt-get install -y \
 	    librrd-dev \
 	    libssh2-1-dev \
 	    libssl-dev \
-	    lz4-dev \
+	    liblz4-dev \
 	    man2html \
 	    munge \
 	    mysql-client \


### PR DESCRIPTION
package name appears to have changed in new ubuntu