### PR TITLE
Add pmix-devel package to slurm_build_centos7

### DIFF
--- a/slurm_build_centos7/Dockerfile
+++ b/slurm_build_centos7/Dockerfile
@@ -33,6 +33,7 @@ RUN yum -y install \
 	    pam-devel \
 	    perl-ExtUtils-MakeMaker \
 	    perl-ExtUtils-ParseXS \
+	    pmix-devel \
 	    python3 \
 	    readline-devel \
 	    rrdtool-devel \


### PR DESCRIPTION
This is needed by bug 9467 to compile slurm on centos7 with pmix.